### PR TITLE
feat: add AaveAdapter

### DIFF
--- a/src/adapters/aave/AaveAdapter.sol
+++ b/src/adapters/aave/AaveAdapter.sol
@@ -2,32 +2,77 @@
 pragma solidity 0.8.10;
 
 // External references
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "../../interfaces/aave/ILendingPool.sol";
+import {IAToken} from "../../interfaces/aave/IAToken.sol";
+import {ILendingPool} from "../../interfaces/aave/ILendingPool.sol";
 
 // Internal references
 import "../BaseAdapter.sol";
 
-/// @title AaveV3 Adapter
-/// NOTE: Aave V3 https://docs.aave.com/developers/tokens/atoken
+/// @title AaveV2 Adapter
+/// NOTE: Aave V2 https://docs.aave.com/developers/tokens/atoken
 contract AaveAdapter is BaseAdapter {
     using FixedMath for uint256;
-    using SafeERC20 for IERC20;
+    using SafeERC20 for IERC20Metadata;
 
-    constructor(AdapterParams memory _adapterParams) BaseAdapter(_adapterParams) {}
+    // TODO: Select LendingPool by ChainId
+    address public constant LENDING_POOL_V2_MAINNET = 0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9;
+
+    ILendingPool internal _pool;
+
+    constructor(AdapterParams memory _adapterParams) BaseAdapter(_adapterParams) {
+        require(adapterParams.underlying == underlying(), "AaveAdapter: unmatching underlying");
+
+        _pool = ILendingPool(LENDING_POOL_V2_MAINNET);
+
+        // TODO: check how to approve deposit for Aave LendingPool
+        IERC20Metadata(_adapterParams.underlying).safeApprove(LENDING_POOL_V2_MAINNET, type(uint256).max);
+    }
 
     /// @inheritdoc BaseAdapter
     /// @notice 1:1 exchange rate
+    function scale() external override returns (uint256) {
+        return 1 * 10**(18 - uDecimals);
+    }
+
     function _scale() internal override returns (uint256) {}
 
     /// @inheritdoc BaseAdapter
-    function underlying() public view override returns (address) {}
+    function underlying() public view override returns (address) {
+        address target = adapterParams.target;
+        return IAToken(target).UNDERLYING_ASSET_ADDRESS();
+    }
 
     /// @inheritdoc BaseAdapter
     /// @dev no funds should be left in the contract after this call
-    function wrapUnderlying(uint256 uBal) external override returns (uint256) {}
+    function wrapUnderlying(uint256 uBal) external override returns (uint256) {
+        require(IERC20Metadata(underlying()).balanceOf(address(msg.sender)) >= uBal, "AaveAdapter: Insufficient uBal");
+
+        IERC20Metadata target = IERC20Metadata(adapterParams.target);
+        uint256 tBalBefore = target.balanceOf(msg.sender);
+
+        _pool.deposit(underlying(), uBal, msg.sender, 0);
+
+        uint256 tBalAfter = target.balanceOf(msg.sender);
+        uint256 tBal = tBalAfter - tBalBefore;
+        require(tBal == uBal, "AaveAdapter: Balance Inequality");
+        return tBal;
+    }
 
     /// @inheritdoc BaseAdapter
     /// @dev no funds should be left in the contract after this call
-    function unwrapTarget(uint256 tBal) external override returns (uint256) {}
+    function unwrapTarget(uint256 tBal) external override returns (uint256) {
+        require(IERC20Metadata(adapterParams.target).balanceOf(address(msg.sender)) >= tBal, "AaveAdapter: Insufficient tBal");
+
+        uint256 uBalBefore = IERC20Metadata(underlying()).balanceOf(msg.sender);
+
+        uint256 withdrawnAmount = _pool.withdraw(adapterParams.target, tBal, msg.sender);
+
+        uint256 uBalAfter = IERC20Metadata(underlying()).balanceOf(msg.sender);
+        uint256 uBal = uBalAfter - uBalBefore;
+        require(uBal == tBal, "AaveAdapter: Balance Inequality");
+        require(uBal == withdrawnAmount, "AaveAdapter: Balance Inequality");
+        return uBal;
+    }
 }

--- a/src/adapters/aave/AaveAdapter.sol
+++ b/src/adapters/aave/AaveAdapter.sol
@@ -22,7 +22,10 @@ contract AaveAdapter is BaseAdapter {
     ILendingPool internal _pool;
 
     constructor(AdapterParams memory _adapterParams) BaseAdapter(_adapterParams) {
-        require(adapterParams.underlying == IAToken(_adapterParams.target).UNDERLYING_ASSET_ADDRESS(), "AaveAdapter: unmatching underlying");
+        require(
+            adapterParams.underlying == IAToken(_adapterParams.target).UNDERLYING_ASSET_ADDRESS(),
+            "AaveAdapter: unmatching underlying"
+        );
 
         _pool = ILendingPool(LENDING_POOL_V2_MAINNET);
 
@@ -65,7 +68,10 @@ contract AaveAdapter is BaseAdapter {
     /// @dev no funds should be left in the contract after this call
     function unwrapTarget(uint256 tBal) external override returns (uint256) {
         require(tBal > 0, "AaveAdapter: tBal lower than 0");
-        require(IERC20Metadata(adapterParams.target).balanceOf(address(msg.sender)) >= tBal, "AaveAdapter: Insufficient tBal");
+        require(
+            IERC20Metadata(adapterParams.target).balanceOf(address(msg.sender)) >= tBal,
+            "AaveAdapter: Insufficient tBal"
+        );
 
         uint256 uBalBefore = IERC20Metadata(underlying()).balanceOf(msg.sender);
 

--- a/src/adapters/aave/AaveAdapter.sol
+++ b/src/adapters/aave/AaveAdapter.sol
@@ -84,13 +84,15 @@ contract AaveAdapter is BaseAdapter {
     /// @param decimals decimals of the token
     function _normalize(uint256 amount, uint8 decimals) internal pure returns (uint256) {
         // If we need to increase the decimals
-        if (decimals >= 18) {
+        if (decimals > 18) {
             // Then we shift right the amount by the number of decimals
             amount = amount / 10**(decimals - 18);
             // If we need to decrease the number
-        } else {
+        } else if (decimals < 18) {
             // then we shift left by the difference
             amount = amount * 10**(18 - decimals);
+        } else if (decimals == 18) {
+            amount = amount * 10**18;
         }
         // If nothing changed this is a no-op
         return amount;

--- a/src/adapters/aave/AaveAdapter.sol
+++ b/src/adapters/aave/AaveAdapter.sol
@@ -22,7 +22,7 @@ contract AaveAdapter is BaseAdapter {
     ILendingPool internal _pool;
 
     constructor(AdapterParams memory _adapterParams) BaseAdapter(_adapterParams) {
-        require(adapterParams.underlying == underlying(), "AaveAdapter: unmatching underlying");
+        require(adapterParams.underlying == IAToken(_adapterParams.target).UNDERLYING_ASSET_ADDRESS(), "AaveAdapter: unmatching underlying");
 
         _pool = ILendingPool(LENDING_POOL_V2_MAINNET);
 
@@ -33,25 +33,26 @@ contract AaveAdapter is BaseAdapter {
     /// @inheritdoc BaseAdapter
     /// @notice 1:1 exchange rate
     function scale() external override returns (uint256) {
-        return 1 * 10**(18 - uDecimals);
+        return _normalize(1, uDecimals);
     }
 
     function _scale() internal override returns (uint256) {}
 
     /// @inheritdoc BaseAdapter
     function underlying() public view override returns (address) {
-        address target = adapterParams.target;
-        return IAToken(target).UNDERLYING_ASSET_ADDRESS();
+        return adapterParams.underlying;
     }
 
     /// @inheritdoc BaseAdapter
     /// @dev no funds should be left in the contract after this call
     function wrapUnderlying(uint256 uBal) external override returns (uint256) {
+        require(uBal > 0, "AaveAdapter: uBal lower than 0");
         require(IERC20Metadata(underlying()).balanceOf(address(msg.sender)) >= uBal, "AaveAdapter: Insufficient uBal");
 
         IERC20Metadata target = IERC20Metadata(adapterParams.target);
         uint256 tBalBefore = target.balanceOf(msg.sender);
 
+        IERC20Metadata(underlying()).safeTransferFrom(msg.sender, address(this), uBal);
         _pool.deposit(underlying(), uBal, msg.sender, 0);
 
         uint256 tBalAfter = target.balanceOf(msg.sender);
@@ -63,10 +64,12 @@ contract AaveAdapter is BaseAdapter {
     /// @inheritdoc BaseAdapter
     /// @dev no funds should be left in the contract after this call
     function unwrapTarget(uint256 tBal) external override returns (uint256) {
+        require(tBal > 0, "AaveAdapter: tBal lower than 0");
         require(IERC20Metadata(adapterParams.target).balanceOf(address(msg.sender)) >= tBal, "AaveAdapter: Insufficient tBal");
 
         uint256 uBalBefore = IERC20Metadata(underlying()).balanceOf(msg.sender);
 
+        IERC20Metadata(adapterParams.target).safeTransferFrom(msg.sender, address(this), tBal);
         uint256 withdrawnAmount = _pool.withdraw(adapterParams.target, tBal, msg.sender);
 
         uint256 uBalAfter = IERC20Metadata(underlying()).balanceOf(msg.sender);
@@ -74,5 +77,22 @@ contract AaveAdapter is BaseAdapter {
         require(uBal == tBal, "AaveAdapter: Balance Inequality");
         require(uBal == withdrawnAmount, "AaveAdapter: Balance Inequality");
         return uBal;
+    }
+
+    /// @dev to 18 point decimal
+    /// @param amount The amount of the token in native decimal encoding
+    /// @param decimals decimals of the token
+    function _normalize(uint256 amount, uint8 decimals) internal pure returns (uint256) {
+        // If we need to increase the decimals
+        if (decimals >= 18) {
+            // Then we shift right the amount by the number of decimals
+            amount = amount / 10**(decimals - 18);
+            // If we need to decrease the number
+        } else {
+            // then we shift left by the difference
+            amount = amount * 10**(18 - decimals);
+        }
+        // If nothing changed this is a no-op
+        return amount;
     }
 }

--- a/src/interfaces/aave/IAToken.sol
+++ b/src/interfaces/aave/IAToken.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+/**
+ * @title IAToken
+ * @author Aave
+ * @notice Defines the basic interface for an AToken.
+ **/
+interface IAToken is IERC20Metadata {
+  /**
+   * @notice Returns the address of the underlying asset of this aToken (E.g. WETH for aWETH)
+   * @return The address of the underlying asset
+   **/
+  function UNDERLYING_ASSET_ADDRESS() external view returns (address);
+}

--- a/src/interfaces/aave/IAToken.sol
+++ b/src/interfaces/aave/IAToken.sol
@@ -9,9 +9,9 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
  * @notice Defines the basic interface for an AToken.
  **/
 interface IAToken is IERC20Metadata {
-  /**
-   * @notice Returns the address of the underlying asset of this aToken (E.g. WETH for aWETH)
-   * @return The address of the underlying asset
-   **/
-  function UNDERLYING_ASSET_ADDRESS() external view returns (address);
+    /**
+     * @notice Returns the address of the underlying asset of this aToken (E.g. WETH for aWETH)
+     * @return The address of the underlying asset
+     **/
+    function UNDERLYING_ASSET_ADDRESS() external view returns (address);
 }

--- a/src/interfaces/aave/ILendingPool.sol
+++ b/src/interfaces/aave/ILendingPool.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.10;
+
+interface ILendingPool {
+    /**
+    * @dev Deposits an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+    * - E.g. User deposits 100 USDC and gets in return 100 aUSDC
+    * @param asset The address of the underlying asset to deposit
+    * @param amount The amount to be deposited
+    * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+    *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+    *   is a different wallet
+    * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+    *   0 if the action is executed directly by the user, without any middle-man
+    **/
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16 referralCode
+    ) external;
+
+    /**
+    * @dev Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
+    * E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
+    * @param asset The address of the underlying asset to withdraw
+    * @param amount The underlying amount to be withdrawn
+    *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
+    * @param to Address that will receive the underlying, same as msg.sender if the user
+    *   wants to receive it on his own wallet, or a different address if the beneficiary is a
+    *   different wallet
+    * @return The final amount withdrawn
+    **/
+    function withdraw(
+        address asset,
+        uint256 amount,
+        address to
+    ) external returns (uint256);
+}

--- a/src/interfaces/aave/ILendingPool.sol
+++ b/src/interfaces/aave/ILendingPool.sol
@@ -3,16 +3,16 @@ pragma solidity ^0.8.10;
 
 interface ILendingPool {
     /**
-    * @dev Deposits an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
-    * - E.g. User deposits 100 USDC and gets in return 100 aUSDC
-    * @param asset The address of the underlying asset to deposit
-    * @param amount The amount to be deposited
-    * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
-    *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
-    *   is a different wallet
-    * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
-    *   0 if the action is executed directly by the user, without any middle-man
-    **/
+     * @dev Deposits an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+     * - E.g. User deposits 100 USDC and gets in return 100 aUSDC
+     * @param asset The address of the underlying asset to deposit
+     * @param amount The amount to be deposited
+     * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+     *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+     *   is a different wallet
+     * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+     *   0 if the action is executed directly by the user, without any middle-man
+     **/
     function deposit(
         address asset,
         uint256 amount,
@@ -21,16 +21,16 @@ interface ILendingPool {
     ) external;
 
     /**
-    * @dev Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
-    * E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
-    * @param asset The address of the underlying asset to withdraw
-    * @param amount The underlying amount to be withdrawn
-    *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
-    * @param to Address that will receive the underlying, same as msg.sender if the user
-    *   wants to receive it on his own wallet, or a different address if the beneficiary is a
-    *   different wallet
-    * @return The final amount withdrawn
-    **/
+     * @dev Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
+     * E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
+     * @param asset The address of the underlying asset to withdraw
+     * @param amount The underlying amount to be withdrawn
+     *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
+     * @param to Address that will receive the underlying, same as msg.sender if the user
+     *   wants to receive it on his own wallet, or a different address if the beneficiary is a
+     *   different wallet
+     * @return The final amount withdrawn
+     **/
     function withdraw(
         address asset,
         uint256 amount,

--- a/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
+++ b/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
@@ -5,6 +5,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 
 import "../../../tokens/Tranche.sol";
 import "../../../adapters/aave/AaveAdapter.sol";
+import {ILendingPool} from "../../../interfaces/aave/ILendingPool.sol";
 
 import "../../../utils/FixedMath.sol";
 
@@ -15,6 +16,9 @@ contract TestAaveAdapterADAI is TestAdapter {
 
     address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address internal constant aDAI = 0x028171bCA77440897B824Ca71D1c56caC55b68A3;
+    address internal constant LENDING_POOL_V2_MAINNET = 0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9;
+
+    ILendingPool internal _pool;
 
     function _setup() internal override {
         feePst = 0;
@@ -26,6 +30,8 @@ contract TestAaveAdapterADAI is TestAdapter {
             Adapter.AdapterParams({underlying: DAI, target: aDAI, delta: DELTA, minm: 0, maxm: 0, issuanceFee: feePst})
         );
 
+        _pool = ILendingPool(LENDING_POOL_V2_MAINNET);
+
         Adapter[] memory adapters = new Adapter[](1);
         adapters[0] = adapter;
         tranche = new Tranche(
@@ -35,5 +41,16 @@ contract TestAaveAdapterADAI is TestAdapter {
             address(this),
             INapierPoolFactory(address(this))
         );
+
+        _fund();
+    }
+
+    function _fund() internal override virtual {
+        U_DECIMALS = IERC20Metadata(underlying).decimals();
+        T_DECIMALS = IERC20Metadata(target).decimals();
+        U_BASE = 10**U_DECIMALS;
+        T_BASE = 10**T_DECIMALS;
+
+        deal(underlying, address(this), 2000 * U_BASE, true);
     }
 }

--- a/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
+++ b/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
@@ -45,7 +45,7 @@ contract TestAaveAdapterADAI is TestAdapter {
         _fund();
     }
 
-    function _fund() internal override virtual {
+    function _fund() internal virtual override {
         U_DECIMALS = IERC20Metadata(underlying).decimals();
         T_DECIMALS = IERC20Metadata(target).decimals();
         U_BASE = 10**U_DECIMALS;

--- a/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
+++ b/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.10;
+
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import "../../../tokens/Tranche.sol";
+import "../../../adapters/aave/AaveAdapter.sol";
+
+import "../../../utils/FixedMath.sol";
+
+import "../TestAdapter.t.sol";
+
+contract TestAaveAdapterADAI is TestAdapter {
+    using FixedMath for uint256;
+
+    address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address internal constant aDAI = 0x028171bCA77440897B824Ca71D1c56caC55b68A3;
+
+    function _setup() internal override {
+        feePst = 0;
+        maturity = block.timestamp + 10 weeks;
+        underlying = DAI;
+        target = aDAI;
+
+        adapter = new AaveAdapter(
+            Adapter.AdapterParams({underlying: DAI, target: aDAI, delta: DELTA, minm: 0, maxm: 0, issuanceFee: feePst})
+        );
+
+        Adapter[] memory adapters = new Adapter[](1);
+        adapters[0] = adapter;
+        tranche = new Tranche(
+            adapters,
+            IERC20Metadata(underlying),
+            maturity,
+            address(this),
+            INapierPoolFactory(address(this))
+        );
+    }
+}

--- a/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
+++ b/src/tests/adapters/aave/TestAaveAdapterADAI.t.sol
@@ -45,12 +45,15 @@ contract TestAaveAdapterADAI is TestAdapter {
         _fund();
     }
 
-    function _fund() internal override virtual {
+    function _fund() internal virtual override {
         U_DECIMALS = IERC20Metadata(underlying).decimals();
         T_DECIMALS = IERC20Metadata(target).decimals();
         U_BASE = 10**U_DECIMALS;
         T_BASE = 10**T_DECIMALS;
 
         deal(underlying, address(this), 2000 * U_BASE, true);
+
+        IERC20(underlying).approve(address(_pool), type(uint256).max);
+        _pool.deposit(underlying, 1000 * U_BASE, address(this), 0);
     }
 }


### PR DESCRIPTION
This is my first stab at adding the aave adapter. 

The Aave adapter deposits and withdraws user's underlying and target token on behalf into Aave v2 LendingPool. The LendingPool contract transfers the aToken to the user.


I'm having a trouble validating my logic through tests. Here is the error log that I get, but I'm not sure how to debug it.

```
Failing tests:
Encountered 1 failing test in src/tests/adapters/aave/TestAaveAdapterADAI.t.sol:TestAaveAdapterADAI
[FAIL. Reason: Setup failed: stdStorage find(StdStorage): Slot(s) not found.] setUp() (gas: 0)
```